### PR TITLE
Bump `get-stream`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "file-type": "^3.8.0",
-    "get-stream": "^2.2.0",
+    "get-stream": "^3.0.0",
     "pify": "^2.3.0",
     "yauzl": "^2.4.2"
   },


### PR DESCRIPTION
`get-stream@3.0.0` requires `node@4` and subsequently drops the polyfill dependencies.