### PR TITLE
fix Error: EISDIR: illegal operation on a directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const getType = (entry, mode) => {
 		return 'symlink';
 	}
 
-	if ((mode & IFMT) === IFDIR || (madeBy === 0 && entry.externalFileAttributes === 16)) {
+	if ((mode & IFMT) === IFDIR || (madeBy === 0 && entry.externalFileAttributes === 16) || /\/$/.test(entry.fileName)) {
 		return 'directory';
 	}
 


### PR DESCRIPTION
In some windows environment, compressed zip package, repair is a folder judgment．

[nssm-2.24-7zip.zip](https://github.com/kevva/decompress-unzip/files/2301239/nssm-2.24-7zip.zip)

