### PR TITLE
expose options to pass through to yauzl

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ const extractFile = zip => new Promise((resolve, reject) => {
 	zip.on('end', () => resolve(files));
 });
 
-module.exports = () => buf => {
+module.exports = opts => buf => {
 	if (!Buffer.isBuffer(buf)) {
 		return Promise.reject(new TypeError(`Expected a Buffer, got ${typeof buf}`));
 	}
@@ -82,5 +82,7 @@ module.exports = () => buf => {
 		return Promise.resolve([]);
 	}
 
-	return pify(yauzl.fromBuffer)(buf, {lazyEntries: true}).then(extractFile);
+	opts = Object.assign({lazyEntries: true}, opts || {});
+
+	return pify(yauzl.fromBuffer)(buf, opts).then(extractFile);
 };


### PR DESCRIPTION
Hi @kevva 

Any interest in exposing the yauzl options though?

I'm specifically interested in setting `validateEntrySizes: false` because I have a bunch of zips to decompress that I can't control.

This option was added to yauzl here: https://github.com/thejoshwolfe/yauzl/commit/4c0aef8024498ff07fb1b25bf16b31366c01e2ec